### PR TITLE
Disable local explorer node temporarily

### DIFF
--- a/protocol/settings/Devnet.toml
+++ b/protocol/settings/Devnet.toml
@@ -73,7 +73,7 @@ balance = 100_000_000_000_000
 # btc_address: mjSrB3wS4xab3kYqFktwBzfTdPg367ZJ2d
 
 [devnet]
-disable_stacks_explorer = false
+disable_stacks_explorer = true
 disable_stacks_api = false
 # disable_bitcoin_explorer = true
 # working_dir = "tmp/devnet"


### PR DESCRIPTION
The latest docker image from hiro apparently has some issues related to switching to custom network (fails with HTTP 500), so I'm disabling launching it as part of the environment for now. Instead an explicit explorer instance will be launched on the staging environments. This can be reverted once the issue is resolved upstream.